### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ay-alu/8cf47f15-2421-4980-b11c-72f90ffcf768/7f38c7ff-5139-48fc-a054-589023b14ffe/_apis/work/boardbadge/7c9f1aa8-bd68-45be-8c08-ea13986638b4)](https://dev.azure.com/ay-alu/8cf47f15-2421-4980-b11c-72f90ffcf768/_boards/board/t/7f38c7ff-5139-48fc-a054-589023b14ffe/Microsoft.EpicCategory)
 
 # GreenLife-Eco-Tracker  
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#95](https://dev.azure.com/ay-alu/8cf47f15-2421-4980-b11c-72f90ffcf768/_workitems/edit/95). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.